### PR TITLE
Some changes for efficiency(not yet)

### DIFF
--- a/src/main/java/ru/windcorp/progressia/client/world/ChunkRender.java
+++ b/src/main/java/ru/windcorp/progressia/client/world/ChunkRender.java
@@ -102,7 +102,9 @@ public class ChunkRender
 	}
 
 	public synchronized void render(ShapeRenderHelper renderer) {
-		model.render(renderer);
+		if (!data.isEmpty) {
+			model.render(renderer);
+		}
 	}
 
 	public synchronized void update() {

--- a/src/main/java/ru/windcorp/progressia/common/world/DefaultChunkData.java
+++ b/src/main/java/ru/windcorp/progressia/common/world/DefaultChunkData.java
@@ -25,8 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
-
 import glm.vec._3.i.Vec3i;
 
 import ru.windcorp.progressia.common.world.block.BlockData;
@@ -45,6 +45,11 @@ public class DefaultChunkData implements ChunkData {
 
 	public static final int BLOCKS_PER_CHUNK = Coordinates.CHUNK_SIZE;
 	public static final int CHUNK_RADIUS = BLOCKS_PER_CHUNK / 2;
+	
+	public boolean isEmpty = false;
+	public boolean isOpaque = false;
+	
+	public static HashSet<BlockData> transparent;
 
 	private final Vec3i position = new Vec3i();
 	private final DefaultWorldData world;
@@ -199,6 +204,44 @@ public class DefaultChunkData implements ChunkData {
 	public void setGenerationHint(Object generationHint) {
 		this.generationHint = generationHint;
 	}
+	
+	public void computeOpaque()
+	{
+		for (int xyz=0;xyz<BLOCKS_PER_CHUNK*BLOCKS_PER_CHUNK*BLOCKS_PER_CHUNK;xyz++)
+		{
+			if (transparent.contains( blocks[xyz]))
+			{
+				isOpaque = false;
+				return;
+			}
+		}
+		isOpaque = true;
+	}
+	
+	public boolean isOpaque()
+	{
+		return isOpaque;
+	}
+	
+	public void computeEmpty()
+	{
+		BlockData air = new BlockData("Test:Air");
+		for (int xyz=0;xyz<BLOCKS_PER_CHUNK*BLOCKS_PER_CHUNK*BLOCKS_PER_CHUNK;xyz++)
+		{
+			if (blocks[xyz] != air)
+			{
+				isEmpty = false;
+				return;
+			}
+		}
+		isEmpty = true;
+	}
+	
+	public boolean isEmpty()
+	{
+		return isEmpty;
+	}
+
 
 	/**
 	 * Implementation of {@link TileDataStack} used internally by

--- a/src/main/java/ru/windcorp/progressia/server/world/generation/planet/PlanetFeatureGenerator.java
+++ b/src/main/java/ru/windcorp/progressia/server/world/generation/planet/PlanetFeatureGenerator.java
@@ -56,6 +56,9 @@ public class PlanetFeatureGenerator {
 			generateBorderFeatures(server, chunk);
 		}
 		
+		chunk.computeEmpty();
+		chunk.computeOpaque();
+		
 		chunk.setGenerationHint(true);
 	}
 


### PR DESCRIPTION
-Tried to use threads/executors in ChunkRequestDaemon, it just hangs.
-Added isEmpty and isOpaque attributes to DefaultChunkData (should this
just be in ChunkData?)
	-Added compute and getter functions to access(for everything after
loading)
	-Doesn't render empty chunks(not yet used)
-Using format 65537 allows the empty and opaqueness to be saved. They do
not do anything yet and there is no way to set them yet
	-Added loadRegionX and ".progressia_chunkx" file
-removed formats 0 and 1, which use individual chunk files.